### PR TITLE
feat: implement core empty stubs (parsers, scoring, RBAC)

### DIFF
--- a/apps/api/domain/curriculum/section_rules.py
+++ b/apps/api/domain/curriculum/section_rules.py
@@ -1,0 +1,141 @@
+"""
+Curriculum section definitions.
+
+Each section represents a distinct aspect of a curriculum that we want
+to analyze separately. Chunks get classified into one of these sections
+(via embedding similarity or LLM classification), then scored per-section
+against the rigor rubric.
+
+The `description` field is what gets embedded for similarity matching
+against incoming chunks — keep it detailed.
+
+The `keywords` field provides a cheap fallback when embeddings aren't
+available (useful for tests and dev mode).
+"""
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Section:
+    id: str              # Stable ID used in DB + prompts
+    name: str            # Human-readable label for the UI
+    description: str     # Used for embedding-based classification
+    keywords: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Curriculum Sections
+# ---------------------------------------------------------------------------
+
+SECTIONS: list[Section] = [
+    Section(
+        id="course_schedule",
+        name="Course Schedule",
+        description=(
+            "The semester-by-semester plan of courses, including fall and spring "
+            "offerings, course numbers, credit hours per term, and sequencing. "
+            "Covers what a typical student takes each semester."
+        ),
+        keywords=["fall", "spring", "semester", "schedule", "year 1", "sophomore", "junior", "senior"],
+    ),
+    Section(
+        id="core_requirements",
+        name="Core Requirements",
+        description=(
+            "Required foundational courses that every student in the program must "
+            "complete. Includes math prerequisites, intro sequences, and core "
+            "discipline courses with no substitution allowed."
+        ),
+        keywords=["required", "core", "mandatory", "prerequisite", "foundation"],
+    ),
+    Section(
+        id="specialization_paths",
+        name="Specialization Paths",
+        description=(
+            "Optional tracks, concentrations, focus areas, or depth options. "
+            "Covers how many specializations are offered, what each consists of, "
+            "and how selective or deep each track is."
+        ),
+        keywords=["concentration", "track", "focus area", "specialization", "depth", "breadth"],
+    ),
+    Section(
+        id="electives",
+        name="Electives",
+        description=(
+            "Free electives, technical electives, and non-core course choices. "
+            "Includes the number of elective credits required, restrictions on "
+            "what counts, and availability of advanced electives."
+        ),
+        keywords=["elective", "optional", "free choice", "approved list"],
+    ),
+    Section(
+        id="credit_load",
+        name="Credit Load & Hours",
+        description=(
+            "Total credit hours required to graduate, typical credit load per "
+            "semester, and credit distribution across subject areas. Also covers "
+            "any minimum/maximum credit constraints per term."
+        ),
+        keywords=["credit hour", "units", "credits", "total credits", "credit load"],
+    ),
+    Section(
+        id="capstone_research",
+        name="Capstone & Research",
+        description=(
+            "Senior design projects, capstone courses, thesis requirements, "
+            "undergraduate research opportunities, and independent study options. "
+            "Indicates the degree to which the program requires substantive "
+            "project or research work."
+        ),
+        keywords=["capstone", "senior design", "thesis", "research", "independent study", "project"],
+    ),
+    Section(
+        id="grading_assessment",
+        name="Grading & Assessment",
+        description=(
+            "Grading policies, minimum GPA requirements, exam structures, and "
+            "assessment methods. Indicates the academic standards enforced on "
+            "students throughout the program."
+        ),
+        keywords=["gpa", "grading", "minimum grade", "exam", "assessment", "pass/fail"],
+    ),
+    Section(
+        id="prerequisites_policy",
+        name="Prerequisites Policy",
+        description=(
+            "How prerequisites are enforced, which courses require what, and the "
+            "depth of the prerequisite chains. A program with long, strict "
+            "prerequisite chains is typically more rigorous."
+        ),
+        keywords=["prerequisite", "pre-req", "corequisite", "required before"],
+    ),
+]
+
+
+# Fast lookup by id
+SECTIONS_BY_ID: dict[str, Section] = {s.id: s for s in SECTIONS}
+
+
+def get_section(section_id: str) -> Section | None:
+    """Return a Section by its id, or None if not found."""
+    return SECTIONS_BY_ID.get(section_id)
+
+
+def all_section_ids() -> list[str]:
+    """Return the list of all known section ids."""
+    return [s.id for s in SECTIONS]
+
+
+def classify_by_keywords(text: str) -> str | None:
+    """
+    Cheap keyword-based classifier. Returns the id of the first matching
+    section, or None if no keywords match.
+
+    This is a fallback for when embeddings aren't available. Real
+    classification should use embedding similarity against Section.description.
+    """
+    lower = text.lower()
+    for section in SECTIONS:
+        if any(kw in lower for kw in section.keywords):
+            return section.id
+    return None

--- a/apps/api/domain/scoring/rigor_rubric.py
+++ b/apps/api/domain/scoring/rigor_rubric.py
@@ -1,0 +1,156 @@
+"""
+Rigor scoring rubric.
+
+Defines how each curriculum section contributes to the overall rigor score,
+and the criteria used by the LLM to evaluate a single section.
+
+Flow at comparison time:
+    1. Chunks are grouped by section (see section_rules.py).
+    2. For each section, the LLM is given the chunks + the criteria here and
+       returns a section_score in [0, 100] plus strengths/weaknesses.
+    3. The overall score is a weighted sum of section scores using SECTION_WEIGHTS.
+"""
+from dataclasses import dataclass
+
+from section_rules import all_section_ids
+
+
+# ---------------------------------------------------------------------------
+# Section weights — must sum to 1.0
+# ---------------------------------------------------------------------------
+# These weights reflect how much each section contributes to the final rigor
+# score. Tune as the team converges on what "rigor" means for this product.
+
+SECTION_WEIGHTS: dict[str, float] = {
+    "course_schedule":       0.10,
+    "core_requirements":     0.20,
+    "specialization_paths":  0.15,
+    "electives":             0.05,
+    "credit_load":           0.15,
+    "capstone_research":     0.15,
+    "grading_assessment":    0.10,
+    "prerequisites_policy":  0.10,
+}
+
+
+# ---------------------------------------------------------------------------
+# Per-section scoring criteria
+# ---------------------------------------------------------------------------
+# These strings are injected into the LLM prompt when scoring each section.
+# They tell the model what "more rigorous" looks like for that specific section.
+
+SECTION_CRITERIA: dict[str, str] = {
+    "course_schedule": (
+        "More rigorous programs have dense, well-sequenced schedules with "
+        "advanced courses appearing earlier. Light semesters with mostly "
+        "electives are less rigorous."
+    ),
+    "core_requirements": (
+        "More rigorous programs require a broad, deep set of core courses "
+        "(e.g., theory, systems, math) with no easy substitutions. Programs "
+        "with very few required core courses are less rigorous."
+    ),
+    "specialization_paths": (
+        "More rigorous programs offer multiple deep specialization tracks, "
+        "each with several required advanced courses. Programs with one "
+        "shallow track or no tracks at all are less rigorous."
+    ),
+    "electives": (
+        "More rigorous programs require technical/advanced electives from an "
+        "approved list of challenging courses. Programs that allow any course "
+        "to count as an elective are less rigorous."
+    ),
+    "credit_load": (
+        "More rigorous programs require a higher total credit count and a "
+        "heavier typical per-semester load in the major. Programs with low "
+        "total credits or light per-semester loads are less rigorous."
+    ),
+    "capstone_research": (
+        "More rigorous programs require a substantive capstone, thesis, or "
+        "research experience. Programs with no capstone requirement or only "
+        "a brief group project are less rigorous."
+    ),
+    "grading_assessment": (
+        "More rigorous programs enforce higher minimum GPAs in the major, "
+        "proctored exams, and strict grading policies. Lenient grading, "
+        "pass/fail options for core courses, and low minimum grades reduce rigor."
+    ),
+    "prerequisites_policy": (
+        "More rigorous programs have long, strictly-enforced prerequisite "
+        "chains. Programs where advanced courses can be taken without "
+        "building on earlier courses are less rigorous."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Score container
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SectionScore:
+    section_id: str
+    score: float              # 0 – 100
+    strengths: list[str]
+    weaknesses: list[str]
+
+
+@dataclass
+class RigorResult:
+    overall_score: float      # 0 – 100, weighted average of section scores
+    section_scores: list[SectionScore]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def compute_overall_score(section_scores: list[SectionScore]) -> float:
+    """
+    Weighted average of section scores, rounded to 1 decimal.
+
+    Missing sections are skipped and the remaining weights are renormalized
+    so the final number is always on the same 0–100 scale.
+    """
+    total_weight = 0.0
+    weighted_sum = 0.0
+
+    for s in section_scores:
+        weight = SECTION_WEIGHTS.get(s.section_id, 0.0)
+        if weight <= 0:
+            continue
+        total_weight += weight
+        weighted_sum += weight * s.score
+
+    if total_weight == 0:
+        return 0.0
+
+    return round(weighted_sum / total_weight, 1)
+
+
+def build_section_prompt(section_id: str, chunks: list[str]) -> str:
+    """
+    Build the prompt to send to the LLM for scoring a single section.
+
+    The returned string gets passed as the user message. The LLM is
+    expected to reply with JSON containing score, strengths, weaknesses.
+    """
+    criteria = SECTION_CRITERIA.get(section_id, "")
+    joined = "\n\n---\n\n".join(chunks) if chunks else "(no content found for this section)"
+
+    return (
+        f"You are scoring the '{section_id}' section of a university curriculum.\n\n"
+        f"RUBRIC:\n{criteria}\n\n"
+        f"CONTENT:\n{joined}\n\n"
+        f"Respond with JSON matching this schema exactly:\n"
+        f'{{"score": <0-100>, "strengths": ["..."], "weaknesses": ["..."]}}'
+    )
+
+
+def validate_weights() -> bool:
+    """Sanity check: section weights should cover all sections and sum to ~1.0."""
+    known = set(all_section_ids())
+    weighted = set(SECTION_WEIGHTS.keys())
+    if known != weighted:
+        return False
+    return abs(sum(SECTION_WEIGHTS.values()) - 1.0) < 1e-6

--- a/apps/api/integrations/parsers/link_parser.py
+++ b/apps/api/integrations/parsers/link_parser.py
@@ -1,0 +1,78 @@
+"""
+Link parser: fetches a URL, extracts readable text, and returns chunks
+in the same shape as pdf_parser so downstream consumers don't care about
+the source type.
+"""
+from langchain_community.document_loaders import WebBaseLoader
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from urllib.parse import urlparse
+
+# Mirrors KNOWN_HEADERS in pdf_parser.py — keywords that hint at a section
+KNOWN_HEADERS = [
+    "fall", "spring", "required", "courses", "focus track",
+    "depth", "breadth", "electives", "prerequisites", "credit",
+    "concentration", "major", "minor", "capstone",
+]
+
+
+def is_valid_url(url: str) -> bool:
+    """Validate that the string is a well-formed http(s) URL."""
+    try:
+        parsed = urlparse(url)
+        return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+    except Exception:
+        return False
+
+
+def detect_header(text: str) -> str | None:
+    """Return the first known header keyword found in the chunk, if any."""
+    lower = text.lower()
+    for header in KNOWN_HEADERS:
+        if header in lower:
+            return header
+    return None
+
+
+def parse_link(url: str) -> dict:
+    """
+    Fetch a web page and return its text chunks.
+
+    Returns the same shape as parse_file() in pdf_parser.py so both sources
+    feed into the same downstream pipeline.
+
+    Raises:
+        ValueError: if the URL is malformed.
+        RuntimeError: if the fetch fails or the page has no extractable text.
+    """
+    if not is_valid_url(url):
+        raise ValueError(f"Invalid URL: {url}")
+
+    try:
+        loader = WebBaseLoader(url)
+        docs = loader.load()
+    except Exception as e:
+        raise RuntimeError(f"Failed to fetch {url}: {e}") from e
+
+    if not docs or not any(doc.page_content.strip() for doc in docs):
+        raise RuntimeError(f"No text content found at {url}")
+
+    # Same splitter settings as text_chunker.py for consistency
+    splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+    chunks = splitter.split_documents(docs)
+
+    text_chunks = [
+        {
+            "type": "text",
+            "page": None,          # web pages don't have page numbers
+            "content": chunk.page_content,
+            "header": detect_header(chunk.page_content),
+            "source_url": url,
+        }
+        for chunk in chunks
+        if chunk.page_content.strip()
+    ]
+
+    return {
+        "table_chunks": [],        # TODO: extract HTML tables in a later pass
+        "text_chunks": text_chunks,
+    }

--- a/apps/web/src/components/common/user_auth.tsx
+++ b/apps/web/src/components/common/user_auth.tsx
@@ -1,0 +1,176 @@
+'use client'
+/**
+ * UserAuth: authenticated user menu for the header.
+ *
+ * Shows the user's avatar, name, and role. Clicking opens a dropdown
+ * with profile/settings links (role-gated via rbac.ts) and a sign-out button.
+ *
+ * Falls back to a Sign In link when the user is not authenticated.
+ */
+import Link from 'next/link'
+import { useState, useRef, useEffect } from 'react'
+import { signOut, useSession } from 'next-auth/react'
+import { hasPermission, isAdmin, normalizeRole, PERMISSIONS } from '@/lib/auth/rbac'
+
+export default function UserAuth() {
+  const { data: session, status } = useSession()
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  // Loading skeleton
+  if (status === 'loading') {
+    return (
+      <div className="h-9 w-24 rounded-lg animate-pulse" style={{ background: '#1e2740' }} />
+    )
+  }
+
+  // Unauthenticated
+  if (!session?.user) {
+    return (
+      <Link
+        href="/login"
+        className="px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors"
+        style={{ background: '#4d7cfe' }}
+      >
+        Sign In
+      </Link>
+    )
+  }
+
+  const user = session.user
+  const role = normalizeRole(user.role)
+  const displayName = user.name?.trim() || user.email?.split('@')[0] || 'User'
+  const initial = displayName.charAt(0).toUpperCase()
+
+  return (
+    <div className="relative" ref={menuRef}>
+      {/* Trigger button */}
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="flex items-center gap-2.5 px-3 py-1.5 rounded-lg transition-colors hover:bg-white/5"
+      >
+        {/* Avatar */}
+        <div
+          className="flex items-center justify-center w-8 h-8 rounded-full text-sm font-bold text-white"
+          style={{ background: '#4d7cfe' }}
+        >
+          {initial}
+        </div>
+        {/* Name + role */}
+        <div className="text-left hidden sm:block">
+          <div className="text-[13px] font-medium leading-tight" style={{ color: '#e8edf8' }}>
+            {displayName}
+          </div>
+          <div className="text-[10px] capitalize" style={{ color: '#6b7a9e' }}>
+            {role.replace('default.', '')}
+          </div>
+        </div>
+        {/* Chevron */}
+        <span
+          className="text-xs transition-transform"
+          style={{
+            color: '#6b7a9e',
+            transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
+          }}
+        >
+          ▾
+        </span>
+      </button>
+
+      {/* Dropdown */}
+      {open && (
+        <div
+          className="absolute right-0 mt-2 w-56 rounded-xl overflow-hidden z-50"
+          style={{ background: '#111520', border: '1px solid #1e2740' }}
+        >
+          {/* Header */}
+          <div className="px-4 py-3" style={{ borderBottom: '1px solid #1e2740' }}>
+            <div className="text-[13px] font-medium truncate" style={{ color: '#e8edf8' }}>
+              {displayName}
+            </div>
+            <div className="text-[11px] truncate" style={{ color: '#6b7a9e' }}>
+              {user.email}
+            </div>
+          </div>
+
+          {/* Menu items */}
+          <div className="py-1">
+            <MenuItem href="/dashboard" label="Dashboard" icon="⊟" onClick={() => setOpen(false)} />
+            <MenuItem href="/settings"  label="Settings"  icon="⚙" onClick={() => setOpen(false)} />
+
+            {/* Admin-only */}
+            {isAdmin(role) && (
+              <MenuItem
+                href="/admin/users"
+                label="Manage Users"
+                icon="👥"
+                onClick={() => setOpen(false)}
+              />
+            )}
+
+            {/* Permission-gated example */}
+            {hasPermission(role, PERMISSIONS.COMPARISON_CREATE) && (
+              <MenuItem
+                href="/dashboard/compare/new"
+                label="New Comparison"
+                icon="+"
+                onClick={() => setOpen(false)}
+              />
+            )}
+          </div>
+
+          {/* Sign out */}
+          <div style={{ borderTop: '1px solid #1e2740' }}>
+            <button
+              onClick={() => signOut({ callbackUrl: '/login' })}
+              className="flex items-center gap-2.5 w-full px-4 py-2.5 text-[13px] text-left transition-colors hover:bg-white/5"
+              style={{ color: '#f87171' }}
+            >
+              <span>↗</span>
+              Sign Out
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function MenuItem({
+  href,
+  label,
+  icon,
+  onClick,
+}: {
+  href: string
+  label: string
+  icon: string
+  onClick?: () => void
+}) {
+  return (
+    <Link
+      href={href}
+      onClick={onClick}
+      className="flex items-center gap-2.5 px-4 py-2.5 text-[13px] transition-colors hover:bg-white/5"
+      style={{ color: '#a0aec8' }}
+    >
+      <span style={{ color: '#6b7a9e' }}>{icon}</span>
+      {label}
+    </Link>
+  )
+}

--- a/apps/web/src/lib/auth/rbac.ts
+++ b/apps/web/src/lib/auth/rbac.ts
@@ -1,0 +1,112 @@
+/**
+ * Role-Based Access Control (RBAC)
+ *
+ * Defines roles, permissions, and helper functions for checking
+ * whether a user can perform a given action.
+ *
+ * Role strings match what the FastAPI backend returns on login
+ * (see auth.ts — `role: user.role || "default.user"`).
+ */
+
+// ---------------------------------------------------------------------------
+// Role definitions
+// ---------------------------------------------------------------------------
+
+export const ROLES = {
+    ADMIN: 'admin',
+    USER: 'default.user',
+    GUEST: 'guest',
+  } as const
+  
+  export type Role = (typeof ROLES)[keyof typeof ROLES]
+  
+  /** Hierarchy — higher number = more privileges. */
+  const ROLE_HIERARCHY: Record<Role, number> = {
+    [ROLES.ADMIN]: 100,
+    [ROLES.USER]: 10,
+    [ROLES.GUEST]: 0,
+  }
+  
+  // ---------------------------------------------------------------------------
+  // Permission definitions
+  // ---------------------------------------------------------------------------
+  
+  export const PERMISSIONS = {
+    // Sources
+    SOURCE_VIEW:   'source:view',
+    SOURCE_CREATE: 'source:create',
+    SOURCE_UPDATE: 'source:update',
+    SOURCE_DELETE: 'source:delete',
+  
+    // Comparisons
+    COMPARISON_VIEW:   'comparison:view',
+    COMPARISON_CREATE: 'comparison:create',
+    COMPARISON_DELETE: 'comparison:delete',
+  
+    // Admin-only
+    USER_MANAGE:     'user:manage',
+    SYSTEM_SETTINGS: 'system:settings',
+  } as const
+  
+  export type Permission = (typeof PERMISSIONS)[keyof typeof PERMISSIONS]
+  
+  /** Which permissions each role gets. */
+  const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
+    [ROLES.ADMIN]: Object.values(PERMISSIONS),
+    [ROLES.USER]: [
+      PERMISSIONS.SOURCE_VIEW,
+      PERMISSIONS.SOURCE_CREATE,
+      PERMISSIONS.SOURCE_UPDATE,
+      PERMISSIONS.SOURCE_DELETE,
+      PERMISSIONS.COMPARISON_VIEW,
+      PERMISSIONS.COMPARISON_CREATE,
+      PERMISSIONS.COMPARISON_DELETE,
+    ],
+    [ROLES.GUEST]: [],
+  }
+  
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+  
+  /** Normalize an unknown role string to a known Role, defaulting to GUEST. */
+  export function normalizeRole(role: string | undefined | null): Role {
+    if (!role) return ROLES.GUEST
+    return (Object.values(ROLES) as string[]).includes(role) ? (role as Role) : ROLES.GUEST
+  }
+  
+  /** Check whether a role has at least the privileges of `minimum`. */
+  export function hasRole(role: string | undefined | null, minimum: Role): boolean {
+    const r = normalizeRole(role)
+    return ROLE_HIERARCHY[r] >= ROLE_HIERARCHY[minimum]
+  }
+  
+  /** Check whether a role has a specific permission. */
+  export function hasPermission(
+    role: string | undefined | null,
+    permission: Permission
+  ): boolean {
+    const r = normalizeRole(role)
+    return ROLE_PERMISSIONS[r].includes(permission)
+  }
+  
+  /** Check if a role has ALL of the given permissions. */
+  export function hasAllPermissions(
+    role: string | undefined | null,
+    permissions: Permission[]
+  ): boolean {
+    return permissions.every(p => hasPermission(role, p))
+  }
+  
+  /** Check if a role has ANY of the given permissions. */
+  export function hasAnyPermission(
+    role: string | undefined | null,
+    permissions: Permission[]
+  ): boolean {
+    return permissions.some(p => hasPermission(role, p))
+  }
+  
+  /** Shortcut: is this role an admin? */
+  export function isAdmin(role: string | undefined | null): boolean {
+    return normalizeRole(role) === ROLES.ADMIN
+  }


### PR DESCRIPTION
- link_parser.py: fetch + chunk URL content, matches pdf_parser shape
- section_rules.py: define 8 curriculum sections for chunk classification
- rigor_rubric.py: per-section weights, criteria, and scoring helpers
- rbac.ts: role/permission utilities wired to backend role strings
- user_auth.tsx: role-gated user menu dropdown for header

